### PR TITLE
EKS Log Collector Automation: Added nodes_max_limit dynamic

### DIFF
--- a/patterns/auto-analysis/eks-node-log-automation/prometheus/kube-prometheus-stack-values.yaml.tmp
+++ b/patterns/auto-analysis/eks-node-log-automation/prometheus/kube-prometheus-stack-values.yaml.tmp
@@ -7,7 +7,7 @@ additionalPrometheusRulesMap:
       rules:
       - alert: KubeNNR
         annotations:
-          description: '{{ $labels.node }} has been unready for more than 5 minutes.'
+          description: '{{ $labels.node }} has been unready for more than 6 minutes.'
           summary: Node is not ready.
         expr: kube_node_status_condition{job="kube-state-metrics",condition="Ready",status="true"} == 0
         for: 6m
@@ -15,8 +15,8 @@ additionalPrometheusRulesMap:
           severity: warning
       - alert: KubeNNRMax
         annotations:
-          description: 'More than threshold number of nodes in Not Ready state'
-          summary: More than threshold number of nodes are in not ready state.
+          description: 'More than threshold number of nodes in Not Ready state for more than 6 minutes.'
+          summary: More than threshold number of nodes are in not Ready state.
         expr: sum(kube_node_info) - sum(kube_node_status_condition{condition="Ready",job="kube-state-metrics",status="true"}) > clamp_max(ceil(sum(kube_node_info)/5), 5)
         for: 6m
         labels:

--- a/patterns/auto-analysis/eks-node-log-automation/src/lib/kubernetes.py
+++ b/patterns/auto-analysis/eks-node-log-automation/src/lib/kubernetes.py
@@ -74,19 +74,23 @@ class KubeAPI:
         else:
             return cluster_config
 
-    def get_node_info(self, node):
+    def get_nodes_count(self):
         try:
-            node_info = self.core_v1.read_node(name=node)
-            node_status = node_info.status.conditions[-1].type
-            node_addresses = node_info.status.addresses
+            continue_token = None
+            count = 0
+            while True:
+                if continue_token:
+                    node_list = self.core_v1.list_node(limit=100, _continue=continue_token)
+                else:
+                    node_list = self.core_v1.list_node(limit=100)
+                continue_token = node_list.metadata._continue
+                count += len(node_list.items)
+                if continue_token is None:
+                    break
         except client.exceptions.ApiException as error:
             raise error
         else:
-            return {
-                "node": node,
-                "node_status": node_status,
-                "node_addresses": node_addresses
-            }
+            return count
         
     def list_nodes_notready(self, node_limit):
         try:

--- a/patterns/auto-analysis/eks-node-log-automation/template.yaml
+++ b/patterns/auto-analysis/eks-node-log-automation/template.yaml
@@ -67,7 +67,6 @@ Resources:
           SSM_AUTOMATION_EXECUTION_ROLE_ARN: !GetAtt SSMExecutionRole.Arn
           LOG_COLLECTION_BUCKET: !Ref LogCollectionS3Bucket
           BUNDLE_RECENCY_SECONDS: 600
-          LOG_COLLECTION_NODES_MAX: 5
       Events:
         SNSSubscription:
           Type: SNS


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The nodes_max_limit in Lambda will be calculated as `min(20% of total_nodes_count or 5)`. This will ensure that not more than 5 instances are considered for log collection at a time. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
